### PR TITLE
Add scikit-topt to Finite Elements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 
 - [FElupe](https://github.com/adtzlr/felupe) – finite element analysis for continuum mechanics of solid bodies.
 - [fenics-sz](https://github.com/cianwilson/fenics-sz) – Jupyter Book for modeling subduction zones using FEniCSx finite element library.
+- [scikit-topt](https://github.com/kevin-tofu/scikit-topt) – lightweight Python library for topology optimization using finite element analysis.
 - [vfo (Visualization For OpenSees)](https://github.com/u-anurag/vfo) - Visualization For OpenSees.
 
 ## Geometry

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Contributions _very welcome_ but first see [Contributing](CONTRIBUTING.md).
 ## Finite Elements
 
 - [FElupe](https://github.com/adtzlr/felupe) – finite element analysis for continuum mechanics of solid bodies.
+- [fenics-sz](https://github.com/cianwilson/fenics-sz) – Jupyter Book for modeling subduction zones using FEniCSx finite element library.
 - [vfo (Visualization For OpenSees)](https://github.com/u-anurag/vfo) - Visualization For OpenSees.
 
 ## Geometry


### PR DESCRIPTION
## Summary
- Add scikit-topt library to the Finite Elements section
- scikit-topt is a lightweight Python library for topology optimization using finite element analysis

## Test plan
- [x] Verify scikit-topt entry is correctly formatted
- [x] Confirm placement in appropriate section (Finite Elements)
- [x] Check that the link to https://github.com/kevin-tofu/scikit-topt is valid

🤖 Generated with [Claude Code](https://claude.ai/code)